### PR TITLE
Bug: Only the last 'Browse Preview' block renders when multiple are on a page

### DIFF
--- a/asset/js/browse.js
+++ b/asset/js/browse.js
@@ -22,9 +22,7 @@ const browseScripts = () => {
                 if (document.readyState === 'complete') {
                     createMasonryInstance();
                 } else {
-                    window.onload = function () {
-                        createMasonryInstance();
-                    }
+                    window.addEventListener('load', createMasonryInstance);
                 }
             }
         }


### PR DESCRIPTION
Hi,

I've found an issue with the Lively theme when using multiple "Browse Preview" blocks on a single page (e.g., the homepage). Only the very last "Browse Preview" block on the page is displayed, while all the preceding ones remain hidden (presumably with opacity: 0).

To Reproduce:

1. Edit an Omeka S page.
2. Add two or more "Browse Preview" blocks to the page.
3. Save and view the page.
4. Only the final block will be visible.

The Cause: The issue is in the browseScripts function (in asset/js/browse.js). Inside the resources.forEach loop, the createMasonryInstance function is assigned to window.onload when the document state is not 'complete':

```
// ...
} else {
    window.onload = function () {
        createMasonryInstance();
    }
}
// ...
```

Because this is inside a loop, each "Browse Preview" block overwrites the window.onload handler of the previous one. As a result, only the function for the last block is ever executed.

This can be fixed by replacing window.onload = ... with window.addEventListener('load', ...), which allows multiple handlers to be registered without conflict.

Thanks!